### PR TITLE
Correctly parseInt the SUPP entry, not the string itself.

### DIFF
--- a/src/VariantOutput.java
+++ b/src/VariantOutput.java
@@ -404,7 +404,7 @@ public class VariantOutput {
 				}
 				else if(entry.hasInfoField("SUPP"))
 				{
-					varCallsCount = Integer.parseInt("SUPP");
+					varCallsCount = Integer.parseInt(entry.getInfo("SUPP"));
 				}
 				consensus[groupNumber].setInfo("VARCALLS", 
 						varCallsCount + Integer.parseInt(consensus[groupNumber].getInfo("VARCALLS")) + "");


### PR DESCRIPTION
Hi,
I'm not sure what triggers this if/else condition as I've used Jasmine for many other VCFs without issue, but this line will trivally cause a crash as `"SUPP"` is not an integer.
 
https://github.com/mkirsche/Jasmine/blob/12b3862345b21ae5bb659ca077cfdfb021fef3d4/src/VariantOutput.java#L407
 
Other lines in the file have 
```
Integer.parseInt(entry.getInfo("SUPP"));
```
 
and replacing the issue on L407 with that fixes this problem.

I'll still test this on some old datasets to make sure there are no unintended consequences, but should be harmless.
 
Best,
Alex
